### PR TITLE
fix for XML serialization TypeError exception in item.feedback()

### DIFF
--- a/alp/item.py
+++ b/alp/item.py
@@ -63,9 +63,13 @@ def feedback(items):
         data = item.get()
 
         for (k, v) in data["attrib"].iteritems():
+            if v is None:
+                continue
             itemToAdd.set(k, v)
 
         for (k, v) in data["content"].iteritems():
+            if v is None:
+                continue
             if k != "fileIcon" and k != "fileType":
                 child = ET.SubElement(itemToAdd, k)
                 child.text = v


### PR DESCRIPTION
Code:

```
import alp

item = alp.Item(
    title="Title",
    subtitle="Subtitle",
    arg="",
)
alp.feedback(item)
```

Traceback:

```
Traceback (most recent call last):
  File "crash.py", line 9, in <module>
    alp.feedback(item)
  File "/Users/chris/repos/tower-alfred-workflow/net.cjlucas.alfred.tower/alp/item.py", line 88, in feedback
    print ET.tostring(feedback, encoding="utf-8")
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 1127, in tostring
    ElementTree(element).write(file, encoding, method=method)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 821, in write
    serialize(write, self._root, encoding, qnames, namespaces)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 940, in _serialize_xml
    _serialize_xml(write, e, encoding, qnames, None)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 933, in _serialize_xml
    v = _escape_attrib(v, encoding)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 1093, in _escape_attrib
    _raise_serialization_error(text)
  File "/usr/local/Cellar/python/2.7.3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/etree/ElementTree.py", line 1053, in _raise_serialization_error
    "cannot serialize %r (type %s)" % (text, type(text).__name__)
TypeError: cannot serialize None (type NoneType)
```

The python xml library apparently doesn't like NoneType.

This fix will prevent variables equal to None from being serialized.
