### PR TITLE
Change to biplist to allow reading of binary plists

### DIFF
--- a/alp/core.py
+++ b/alp/core.py
@@ -8,6 +8,7 @@ import sys
 import biplist
 import unicodedata
 import codecs
+import six
 
 
 gBundleID = None
@@ -79,11 +80,11 @@ def storage(join=None):
     return nvPath
 
 
-def readPlist(path, binary=True):
+def readPlist(path):
     if not os.path.isabs(path):
         path = storage(path)
         
-    if binary:
+    if isinstance(path, (six.binary_type)):
         return biplist.readPlist(path)
             
     with codecs.open(path, "r", "utf-8") as f:


### PR DESCRIPTION
Hey just making a PR to see if you want to merge this into master. Allows reading of binary plist files.

One big thing:

Users need to install biplist and six using pip/easy_install or whatever their python package manager is.
