### PR TITLE
docs: Fix a few typos

### DIFF
--- a/alp/core_dependencies/biplist/__init__.py
+++ b/alp/core_dependencies/biplist/__init__.py
@@ -670,7 +670,7 @@ class PlistWriter(object):
         writtenReferences = list(self.writtenReferences.items())
         writtenReferences.sort(key=lambda x: x[1])
         for obj,order in writtenReferences:
-            # Porting note: Elsewhere we deliberately replace empty unicdoe strings
+            # Porting note: Elsewhere we deliberately replace empty unicode strings
             # with empty binary strings, but the empty unicode string
             # goes into writtenReferences.  This isn't an issue in Py2
             # because u'' and b'' have the same hash; but it is in

--- a/alp/fuzzy.py
+++ b/alp/fuzzy.py
@@ -137,7 +137,7 @@ def fuzzy_search(query, elements, key=lambda x: x, rank=True, seq=3):
     Returns:
         a ranked list of elements that matches the query
 
-    Fuzzy matching with rankning based on quality of match with two criteria
+    Fuzzy matching with ranking based on quality of match with two criteria
     (a) sequence of characters (e.g. for query 'nor', 'nor' is better then 'nxoxr')
     (b) earlier matches are better (e.g. for query 'nor', 'nor' is better then 'xnor')
     """

--- a/alp/request/bs4/__init__.py
+++ b/alp/request/bs4/__init__.py
@@ -256,7 +256,7 @@ class BeautifulSoup(Tag):
     def _popToTag(self, name, nsprefix=None, inclusivePop=True):
         """Pops the tag stack up to and including the most recent
         instance of the given tag. If inclusivePop is false, pops the tag
-        stack up to but *not* including the most recent instqance of
+        stack up to but *not* including the most recent instance of
         the given tag."""
         #print "Popping to %s" % name
         if name == self.ROOT_TAG_NAME:
@@ -281,7 +281,7 @@ class BeautifulSoup(Tag):
         """Push a start tag on to the stack.
 
         If this method returns None, the tag was rejected by the
-        SoupStrainer. You should proceed as if the tag had not occured
+        SoupStrainer. You should proceed as if the tag had not occurred
         in the document. For instance, if this was a self-closing tag,
         don't call handle_endtag.
         """

--- a/alp/request/bs4/dammit.py
+++ b/alp/request/bs4/dammit.py
@@ -136,7 +136,7 @@ class EntitySubstitution(object):
 
         :param value: A string to be substituted. The less-than sign will
           become &lt;, the greater-than sign will become &gt;, and any
-          ampersands that are not part of an entity defition will
+          ampersands that are not part of an entity definition will
           become &amp;.
 
         :param make_quoted_attribute: If True, then the string will be
@@ -159,7 +159,7 @@ class EntitySubstitution(object):
         in that the goal is to make the result more readable (to those
         with ASCII displays) rather than to recover from
         errors. There's absolutely nothing wrong with a UTF-8 string
-        containg a LATIN SMALL LETTER E WITH ACUTE, but replacing that
+        containing a LATIN SMALL LETTER E WITH ACUTE, but replacing that
         character with "&eacute;" will make it more readable to some
         people.
         """

--- a/alp/request/bs4/element.py
+++ b/alp/request/bs4/element.py
@@ -94,7 +94,7 @@ class PageElement(object):
     #   converted to entities.  This is not recommended, but it's
     #   faster than "minimal".
     # A function - This function will be called on every string that
-    #  needs to undergo entity substition
+    #  needs to undergo entity substitution
     FORMATTERS = {
         "html" : EntitySubstitution.substitute_html,
         "minimal" : EntitySubstitution.substitute_xml,
@@ -488,7 +488,7 @@ class PageElement(object):
         """Force an attribute value into a string representation.
 
         A multi-valued attribute will be converted into a
-        space-separated stirng.
+        space-separated string.
         """
         value = self.get(value, default)
         if isinstance(value, list) or isinstance(value, tuple):
@@ -519,7 +519,7 @@ class PageElement(object):
             return lambda el: el._attr_value_as_string(
                 attribute, '').startswith(value)
         elif operator == '$':
-            # string represenation of `attribute` ends with `value`
+            # string representation of `attribute` ends with `value`
             return lambda el: el._attr_value_as_string(
                 attribute, '').endswith(value)
         elif operator == '*':

--- a/alp/request/requests/adapters.py
+++ b/alp/request/requests/adapters.py
@@ -205,7 +205,7 @@ class HTTPAdapter(BaseAdapter):
         If the message is being sent through a proxy, the full URL has to be
         used. Otherwise, we should only use the path portion of the URL.
 
-        This shoudl not be called from user code, and is only exposed for use
+        This should not be called from user code, and is only exposed for use
         when subclassing the
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
 

--- a/alp/request/requests/models.py
+++ b/alp/request/requests/models.py
@@ -87,7 +87,7 @@ class RequestEncodingMixin(object):
         """Build the body for a multipart/form-data request.
 
         Will successfully encode files when passed as a dict or a list of
-        2-tuples. Order is retained if data is a list of 2-tuples but abritrary
+        2-tuples. Order is retained if data is a list of 2-tuples but arbitrary
         if parameters are supplied as a dict.
 
         """

--- a/alp/request/requests/sessions.py
+++ b/alp/request/requests/sessions.py
@@ -164,7 +164,7 @@ class SessionRedirectMixin(object):
 class Session(SessionRedirectMixin):
     """A Requests session.
 
-    Provides cookie persistience, connection-pooling, and configuration.
+    Provides cookie persistence, connection-pooling, and configuration.
 
     Basic Usage::
 
@@ -474,7 +474,7 @@ class Session(SessionRedirectMixin):
         return r
 
     def get_adapter(self, url):
-        """Returns the appropriate connnection adapter for the given URL."""
+        """Returns the appropriate connection adapter for the given URL."""
         for (prefix, adapter) in self.adapters.items():
 
             if url.startswith(prefix):

--- a/alp/request/requests_cache/backends/storage/dbdict.py
+++ b/alp/request/requests_cache/backends/storage/dbdict.py
@@ -49,7 +49,7 @@ class DbDict(MutableMapping):
         self.table_name = table_name
         self.fast_save = fast_save
         
-        #: Transactions can be commited if this property is set to `True`
+        #: Transactions can be committed if this property is set to `True`
         self.can_commit = True
 
         


### PR DESCRIPTION
There are small typos in:
- alp/core_dependencies/biplist/__init__.py
- alp/fuzzy.py
- alp/request/bs4/__init__.py
- alp/request/bs4/dammit.py
- alp/request/bs4/element.py
- alp/request/requests/adapters.py
- alp/request/requests/models.py
- alp/request/requests/sessions.py
- alp/request/requests_cache/backends/storage/dbdict.py

Fixes:
- Should read `unicode` rather than `unicdoe`.
- Should read `substitution` rather than `substition`.
- Should read `string` rather than `stirng`.
- Should read `should` rather than `shoudl`.
- Should read `representation` rather than `represenation`.
- Should read `ranking` rather than `rankning`.
- Should read `persistence` rather than `persistience`.
- Should read `occurred` rather than `occured`.
- Should read `instance` rather than `instqance`.
- Should read `definition` rather than `defition`.
- Should read `containing` rather than `containg`.
- Should read `connection` rather than `connnection`.
- Should read `committed` rather than `commited`.
- Should read `arbitrary` rather than `abritrary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md